### PR TITLE
Add "names" to register_decoration

### DIFF
--- a/baldcypress/init.lua
+++ b/baldcypress/init.lua
@@ -25,6 +25,7 @@ end
 --
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
+	name = "baldcypress:baldcypress_tree",
 	minetest.register_decoration({
 		deco_type = "schematic",
 		place_on = {"default:sand"},

--- a/bamboo/init.lua
+++ b/bamboo/init.lua
@@ -115,6 +115,7 @@ end
 --
 
 minetest.register_decoration({
+	name = "bamboo:bamboo_tree",
 	deco_type = "schematic",
 	place_on = {"default:dirt_with_grass"},
 	sidelen = 16,

--- a/birch/init.lua
+++ b/birch/init.lua
@@ -104,6 +104,7 @@ else
 end
 
 minetest.register_decoration({
+	name = "birch:birch_tree",
 	deco_type = "schematic",
 	place_on = {place_on},
 	sidelen = 16,

--- a/cherrytree/init.lua
+++ b/cherrytree/init.lua
@@ -70,6 +70,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "cherrytree:cherry_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,

--- a/chestnuttree/init.lua
+++ b/chestnuttree/init.lua
@@ -86,6 +86,7 @@ if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	end
 
 	minetest.register_decoration({
+		name = "chestnuttree:chestnut_tree",
 		deco_type = "schematic",
 		place_on = {place_on},
 		sidelen = 16,

--- a/clementinetree/init.lua
+++ b/clementinetree/init.lua
@@ -50,6 +50,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "clementinetree:clementine_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,

--- a/ebony/init.lua
+++ b/ebony/init.lua
@@ -27,6 +27,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "ebony:ebony_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter"},
 		sidelen = 16,

--- a/hollytree/init.lua
+++ b/hollytree/init.lua
@@ -44,6 +44,7 @@ if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	end
 
 	minetest.register_decoration({
+		name = "hollytree:holly_tree",
 		deco_type = "schematic",
 		place_on = {place_on},
 		sidelen = 16,

--- a/jacaranda/init.lua
+++ b/jacaranda/init.lua
@@ -26,6 +26,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "jacaranda:jacaranda_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter"},
 		sidelen = 16,

--- a/larch/init.lua
+++ b/larch/init.lua
@@ -26,6 +26,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "larch:larch_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_coniferous_litter"},
 		sidelen = 16,

--- a/lemontree/init.lua
+++ b/lemontree/init.lua
@@ -69,6 +69,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "lemontree:lemon_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,

--- a/mahogany/init.lua
+++ b/mahogany/init.lua
@@ -28,6 +28,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "mahogany:mahogany_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter"},
 		sidelen = 16,

--- a/maple/init.lua
+++ b/maple/init.lua
@@ -40,6 +40,7 @@ if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	end
 
 	minetest.register_decoration({
+		name = "maple:maple_tree",
 		deco_type = "schematic",
 		place_on = {place_on},
 		sidelen = 16,

--- a/oak/init.lua
+++ b/oak/init.lua
@@ -65,6 +65,7 @@ if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	end
 
 	minetest.register_decoration({
+		name = "oak:oak_tree",
 		deco_type = "schematic",
 		place_on = {place_on},
 		sidelen = 16,

--- a/palm/init.lua
+++ b/palm/init.lua
@@ -22,6 +22,7 @@ end
 --
 
 minetest.register_decoration({
+	name = "palm:palm_tree",
 	deco_type = "schematic",
 	place_on = {"default:sand"},
 		sidelen = 16,

--- a/pineapple/init.lua
+++ b/pineapple/init.lua
@@ -27,6 +27,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "pineapple:pineapple_shrub",
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter"},
 		sidelen = 16,

--- a/plumtree/init.lua
+++ b/plumtree/init.lua
@@ -88,6 +88,7 @@ if minetest.get_modpath("rainf") then
 	end
 
 	minetest.register_decoration({
+		name = "plumtree:plum_tree",
 		deco_type = "schematic",
 		place_on = {place_on},
 		sidelen = 16,

--- a/pomegranate/init.lua
+++ b/pomegranate/init.lua
@@ -50,6 +50,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+	name = "pomegranate:pomegranate_tree",
 		deco_type = "schematic",
 		place_on = {"default:dry_dirt"},
 		sidelen = 16,

--- a/willow/init.lua
+++ b/willow/init.lua
@@ -27,6 +27,7 @@ end
 
 if mg_name ~= "v6" and mg_name ~= "singlenode" then
 	minetest.register_decoration({
+		name = "willow:willow_tree",
 		deco_type = "schematic",
 		place_on = {"default:dirt"},
 		sidelen = 16,


### PR DESCRIPTION
Loaded a fresh world and could see no differences before and after adding the name field to register_decoration. Output when running cooltrees and using code below - note I manually removed butterflies/fireflies and some other numebred decs that seem to be tied to default:

```
for dec_name,defs in pairs(minetest.registered_decorations) do	
	if not string.find(dec_name, "default") and not string.find(dec_name, "flower") then
		minetest.debug(dec_name)
	end
end
```

```
2021-03-09 14:14:45: [Main]: larch:larch_tree
2021-03-09 14:14:45: [Main]: mahogany:mahogany_tree
2021-03-09 14:14:45: [Main]: ebony:ebony_tree
2021-03-09 14:14:45: [Main]: plumtree:plum_tree
2021-03-09 14:14:45: [Main]: jacaranda:jacaranda_tree
2021-03-09 14:14:45: [Main]: fireflies:firefly_high
2021-03-09 14:14:45: [Main]: bamboo:bamboo_tree
2021-03-09 14:14:45: [Main]: palm:palm_tree
2021-03-09 14:14:45: [Main]: cherrytree:cherry_tree
2021-03-09 14:14:45: [Main]: chestnuttree:chestnut_tree
2021-03-09 14:14:45: [Main]: clementinetree:clementine_tree
2021-03-09 14:14:45: [Main]: maple:maple_tree
2021-03-09 14:14:45: [Main]: oak:oak_tree
2021-03-09 14:14:45: [Main]: hollytree:holly_tree
2021-03-09 14:14:45: [Main]: birch:birch_tree
2021-03-09 14:14:45: [Main]: willow:willow_tree
2021-03-09 14:14:45: [Main]: pineapple:pineapple_shrub
2021-03-09 14:14:45: [Main]: pomegranate:pomegranate_tree
2021-03-09 14:14:45: [Main]: lemontree:lemon_tree
```