### PR TITLE
Fix warnings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,24 @@
+quiet = 1
+codes = true
+
+exclude_files = {
+	".luarocks/*",
+	"worldeditadditions/utils/bit.lua"
+}
+
+
+ignore = {
+	"631", "61[124]",
+	"542",
+	"412",
+	"321/bit",
+	"21[123]"
+}
+
+-- Read-only globals
+read_globals = {
+	"minetest",
+	"default",
+	"doors"
+}
+std = "max"

--- a/baldcypress/init.lua
+++ b/baldcypress/init.lua
@@ -142,6 +142,7 @@ minetest.register_node("baldcypress:dry_branches", {
 	tiles = {"baldcypress_dry_branches.png"},
 	inventory_image = "baldcypress_dry_branches.png",
 	wield_image = "baldcypress_dry_branches.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}
@@ -161,6 +162,7 @@ minetest.register_node("baldcypress:liana", {
 	tiles = {"baldcypress_liana.png"},
 	inventory_image = "baldcypress_liana.png",
 	wield_image = "baldcypress_liana.png",
+	use_texture_alpha = "clip",
 	is_ground_content = false,
 	node_box = {
 		type = "fixed",

--- a/cacaotree/init.lua
+++ b/cacaotree/init.lua
@@ -226,6 +226,7 @@ minetest.register_node("cacaotree:pod", {
 			{-0.25, -0.5, 0, 0.25, 0.0625, 0.5},
 		},
 	},
+	use_texture_alpha = "clip",
 	drop = "cacaotree:cacao_beans 10",
 	groups = {fleshy = 3, dig_immediate = 3, flammable = 2,
 		leafdecay = 3, leafdecay_drop = 1},
@@ -420,6 +421,7 @@ minetest.register_node("cacaotree:liana", {
 	tiles = {"cacaotree_liana.png"},
 	inventory_image = "cacaotree_liana.png",
 	wield_image = "cacaotree_liana.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.0, 0.5, 0.5, 0.0}
@@ -439,6 +441,7 @@ minetest.register_node("cacaotree:flower_creeper", {
 	tiles = {"cacaotree_flower_creeper.png"},
 	inventory_image = "cacaotree_flower_creeper.png",
 	wield_image = "cacaotree_flower_creeper.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}

--- a/ebony/init.lua
+++ b/ebony/init.lua
@@ -64,6 +64,7 @@ minetest.register_node("ebony:sapling", {
 	sunlight_propagates = true,
 	walkable = false,
 	on_timer = grow_new_ebony_tree,
+	use_texture_alpha = "clip",
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -148,6 +149,7 @@ minetest.register_node("ebony:creeper", {
 	tiles = {"ebony_creeper.png"},
 	inventory_image = "ebony_creeper.png",
 	wield_image = "ebony_creeper.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}
@@ -167,6 +169,7 @@ minetest.register_node("ebony:creeper_leaves", {
 	tiles = {"ebony_creeper_leaves.png"},
 	inventory_image = "ebony_creeper_leaves.png",
 	wield_image = "ebony_creeper_leaves.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}
@@ -186,6 +189,7 @@ minetest.register_node("ebony:liana", {
 	tiles = {"ebony_liana.png"},
 	inventory_image = "ebony_liana.png",
 	wield_image = "ebony_liana.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.0, 0.5, 0.5, 0.0}

--- a/larch/init.lua
+++ b/larch/init.lua
@@ -142,6 +142,7 @@ minetest.register_node("larch:moss", {
 	tiles = {"larch_moss.png"},
 	inventory_image = "larch_moss.png",
 	wield_image = "larch_moss.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}

--- a/mahogany/init.lua
+++ b/mahogany/init.lua
@@ -62,6 +62,7 @@ minetest.register_node("mahogany:sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	use_texture_alpha = "clip",
 	on_timer = grow_new_mahogany_tree,
 	selection_box = {
 		type = "fixed",
@@ -147,6 +148,7 @@ minetest.register_node("mahogany:creeper", {
 	tiles = {"mahogany_creeper.png"},
 	inventory_image = "mahogany_creeper.png",
 	wield_image = "mahogany_creeper.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}
@@ -166,6 +168,7 @@ minetest.register_node("mahogany:flower_creeper", {
 	tiles = {"mahogany_flower_creeper.png"},
 	inventory_image = "mahogany_flower_creeper.png",
 	wield_image = "mahogany_flower_creeper.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.49, 0.5, 0.5, 0.5}
@@ -185,6 +188,7 @@ minetest.register_node("mahogany:hanging_creeper", {
 	tiles = {"mahogany_hanging_creeper.png"},
 	inventory_image = "mahogany_hanging_creeper.png",
 	wield_image = "mahogany_hanging_creeper.png",
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, 0.0, 0.5, 0.5, 0.0}


### PR DESCRIPTION
Another pull request!

This one fixes warnings like these:

```
2021-10-10 13:42:57: WARNING[Main]: Texture "TEXTURE_NAME" of NODE_NAME has transparency, assuming use_texture_alpha = "clip".
2021-10-10 13:42:57: WARNING[Main]:   This warning can be a false-positive if unused pixels in the texture are transparent. However if it is meant to be transparent, you *MUST* update the nodedef and set use_texture_alpha = "clip"! This compatibility code will be removed in a few releases.
```

Note that while I've fixed most of them, there are still some for various doors:

```
Texture "palm_door_wood.png" of doors:door_palm_a has transparency, assuming use_texture_alpha = "clip"
```

....I'm suspecting this needs fixing in the default `doors` mod, but I'm not sure what's going on since the default doors mod already sets this appropriately: https://github.com/minetest/minetest_game/blob/master/mods/doors/init.lua#L448

I've also added a .luacheckrc file.

